### PR TITLE
Proxy Support from CLI #84

### DIFF
--- a/client/bin/smee.js
+++ b/client/bin/smee.js
@@ -10,6 +10,7 @@ program
   .option('-t, --target <target>', 'Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
+  .option('-pr, --proxy <proxy>', 'URL to proxy (Typically useful behind corporate firewall)')
   .parse(process.argv)
 
 let target
@@ -26,7 +27,8 @@ async function setup () {
     source = await Client.createChannel()
   }
 
-  const client = new Client({ source, target })
+  const proxy = program.proxy
+  const client = new Client({ source, target, proxy })
   client.start()
 }
 

--- a/client/bin/smee.js
+++ b/client/bin/smee.js
@@ -10,7 +10,7 @@ program
   .option('-t, --target <target>', 'Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
-  .option('-pr, --proxy <proxy>', 'URL to proxy (Typically useful behind corporate firewall)')
+  .option('-pr, --proxy <proxy>', 'URL to proxy (typically useful behind a corporate firewall)')
   .parse(process.argv)
 
 let target

--- a/client/index.js
+++ b/client/index.js
@@ -3,10 +3,11 @@ const EventSource = require('eventsource')
 const superagent = require('superagent')
 
 class Client {
-  constructor ({ source, target, logger = console }) {
+  constructor ({ source, target, proxy, logger = console }) {
     this.source = source
     this.target = target
     this.logger = logger
+    this.proxy = proxy
 
     if (!validator.isURL(this.source)) {
       throw new Error('The provided URL is invalid.')
@@ -42,7 +43,7 @@ class Client {
   }
 
   start () {
-    const events = new EventSource(this.source)
+    const events = this.proxy ? new EventSource(this.source, { proxy: this.proxy }) : new EventSource(this.source)
 
     // Reconnect immediately
     events.reconnectInterval = 0
@@ -53,7 +54,6 @@ class Client {
 
     this.logger.info(`Forwarding ${this.source} to ${this.target}`)
     this.events = events
-
     return events
   }
 }

--- a/client/test/index.test.js
+++ b/client/test/index.test.js
@@ -12,19 +12,19 @@ const logger = {
 }
 
 describe('client', () => {
-  let proxy, host, client, channel
+  let path, host, client, channel
 
   const targetUrl = 'http://example.com/foo/bar'
 
   beforeEach((done) => {
-    proxy = createServer().listen(0, () => {
-      host = `http://127.0.0.1:${proxy.address().port}`
+    path = createServer().listen(0, () => {
+      host = `http://127.0.0.1:${path.address().port}`
       done()
     })
   })
 
   afterEach(() => {
-    proxy && proxy.close()
+    path && path.close()
     client && client.close()
   })
 
@@ -65,7 +65,7 @@ describe('client', () => {
       })
 
       // Send request to proxy server
-      await request(proxy).post(channel).send(payload).expect(200)
+      await request(path).post(channel).send(payload).expect(200)
     })
   })
 
@@ -78,6 +78,20 @@ describe('client', () => {
       const channel = await Client.createChannel()
       expect(channel).toEqual('https://smee.io/abc123')
       expect(req.isDone()).toBe(true)
+    })
+  })
+
+  describe('using proxy', () => {
+    test('Creates event source if proxy is specified', async () => {
+      channel = '/fake-channel'
+      eventSource = client = new Client({
+        source: `${host}${channel}`,
+        target: targetUrl,
+        proxy: 'hello:123@proxy.com',
+        logger
+      }).start()
+      
+      // Somehow check if eventsource has the proxy defined?
     })
   })
 })


### PR DESCRIPTION
This PR is referencing #84

## What I've done
- Added CLI param to support passing proxy URL
- Refractored variable name from `proxy` to `path` as my new addition is referring to proxy as well and I don't want others confused

## What I would like to discuss
- My param currently is `-pr` or `--proxy`. Is this good or should it be changed?
- Is my variable refactor OK?
- How do I write a test for this? See line 94 in test file.
- Is it possible to test this locally without being behind a proxy?