### PR TITLE
Added option to add HTTP headers to the Jenkins call

### DIFF
--- a/bin/smee.js
+++ b/bin/smee.js
@@ -5,6 +5,11 @@ const { version } = require('../package.json')
 
 const Client = require('..')
 
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
 program
   .version(version, '-v, --version')
   .usage('[options]')
@@ -12,6 +17,7 @@ program
   .option('-t, --target <target>', 'Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
+  .option('-H, --header <header>','HTTP header to add to the Jenkins request (i.e "X-Forwarded-User: smeebot"', collect, [])
   .parse(process.argv)
 
 let target
@@ -21,6 +27,15 @@ if (program.target) {
   target = `http://127.0.0.1:${program.port}${program.path}`
 }
 
+let headers = {}
+program.header.forEach(function (h) {
+  var _match = h.match(/^(.*): (.*)$/)
+  if (!_match) {
+    throw new Error("Provided header option is malformed")
+  }
+  headers[_match[1].trim()] = _match[2].trim()
+})
+ 
 async function setup () {
   let source = program.url
 
@@ -28,7 +43,7 @@ async function setup () {
     source = await Client.createChannel()
   }
 
-  const client = new Client({ source, target })
+  const client = new Client({ source, target, headers })
   client.start()
 }
 

--- a/bin/smee.js
+++ b/bin/smee.js
@@ -5,9 +5,9 @@ const { version } = require('../package.json')
 
 const Client = require('..')
 
-function collect(val, memo) {
-  memo.push(val);
-  return memo;
+function collect (val, memo) {
+  memo.push(val)
+  return memo
 }
 
 program
@@ -17,7 +17,7 @@ program
   .option('-t, --target <target>', 'Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
-  .option('-H, --header <header>','HTTP header to add to the Jenkins request (i.e "X-Forwarded-User: smeebot"', collect, [])
+  .option('-H, --header <header>', 'HTTP header to add to the Jenkins request (i.e "X-Forwarded-User: smeebot"', collect, [])
   .parse(process.argv)
 
 let target
@@ -31,11 +31,11 @@ let headers = {}
 program.header.forEach(function (h) {
   var _match = h.match(/^(.*): (.*)$/)
   if (!_match) {
-    throw new Error("Provided header option is malformed")
+    throw new Error('Provided header option is malformed')
   }
   headers[_match[1].trim()] = _match[2].trim()
 })
- 
+
 async function setup () {
   let source = program.url
 

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ const url = require('url')
 const querystring = require('querystring')
 
 class Client {
-  constructor ({ source, target, logger = console }) {
+  constructor ({ source, target, headers, logger = console }) {
     this.source = source
     this.target = target
+    this.headers = headers
     this.logger = logger
 
     if (!validator.isURL(this.source)) {
@@ -24,7 +25,7 @@ class Client {
 
     delete data.query
 
-    const req = superagent.post(target).send(data.body)
+    const req = superagent.post(target).set(this.headers).send(data.body)
 
     delete data.body
 


### PR DESCRIPTION
We host our Jenkins behind a OAuth reverse proxy, and using https://plugins.jenkins.io/reverse-proxy-auth-plugin to authenticate users (basically using a forwarded username in the HTTP header).
So, to be able to use smee-client with a bot user, this PR allows arbitrary HTTP headers to be set in the request to the backing Jenkins using the `-H` or `--header` argument and the full text of the header (i.e `X-Forwarded-User: github`)