### PR TITLE
Delete content-length header so it is recalculated for request.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ class Client {
     const req = superagent.post(target).send(data.body)
 
     delete data.body
+    delete data['content-length']
 
     Object.keys(data).forEach(key => {
       req.set(key, data[key])


### PR DESCRIPTION
This fixes #116.

Content-length should be recalculated but the code was overwriting it with the original length which has changed (for some unknown reason).