### PR TITLE
fixed webhooks forwarging via reverse proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class Client {
     delete data.body
 
     Object.keys(data).forEach(key => {
-      if (key != 'host') {
+      if (key !== 'host') {
         req.set(key, data[key])
       }
     })

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ class Client {
     delete data.body
 
     Object.keys(data).forEach(key => {
-      req.set(key, data[key])
+      if (key != 'host') {
+        req.set(key, data[key])
+      }
     })
 
     req.end((err, res) => {


### PR DESCRIPTION
Removing 'host' header lets to forward webhooks via reverse proxy