### PR TITLE
Fixes failing TLS connections to HTTPS targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ class Client {
     delete data.body
 
     Object.keys(data).forEach(key => {
+      if (key === 'host') {
+        return
+      }
       req.set(key, data[key])
     })
 


### PR DESCRIPTION
All HTTP headers from the source connection get copied to the target connection.  This causes problems with HTTPS targets, if they perform SNI validation.  

Meaning that when proxying smee.io to Jenkins, Jenkins (and thus smee client) throws an SNI validation error and thus replies to smee-client with an HTTP 400, thus causing smee-client to throw an error as well:

```
/var/lib/jenkins/jenkins.log:
2020-03-02 21:34:44.543+0000 [id=13]    WARNING o.e.j.s.SecureRequestCustomizer#customize: Host smee.io does not match SNI X509@71f67a79(jenkins.somenet.local,h=[jenkins.somenet.local, jenkins, localhost],w=[])
2020-03-02 21:34:44.544+0000 [id=13]    WARNING o.e.jetty.server.HttpChannel#handleException: /github-webhook/ org.eclipse.jetty.http.BadMessageException: 400: Host does not match SNI
```

```
# /usr/bin/smee -u https://smee.io/<redacted> -t https://jenkins.somenet.local:8443/github-webhook/

Forwarding https://smee.io/<redacted> to https://jenkins.somenet.local:8443/github-webhook/
Connected https://smee.io/<redacted>
Error: Internal Server Error
    at Request.callback (/usr/lib/node_modules/smee-client/node_modules/superagent/lib/node/index.js:706:15)
    at Stream.<anonymous> (/usr/lib/node_modules/smee-client/node_modules/superagent/lib/node/index.js:916:18)
    at Stream.emit (events.js:321:20)
    at Unzip.<anonymous> (/usr/lib/node_modules/smee-client/node_modules/superagent/lib/node/unzip.js:55:12)
    at Unzip.emit (events.js:333:22)
    at endReadableNT (_stream_readable.js:1201:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  status: 500,
  response: <ref *1> Response {
    _events: [Object: null prototype] {},
    _eventsCount: 0,
    _maxListeners: undefined,
    res: IncomingMessage {
      _readableState: [ReadableState],
      readable: false,
      _events: [Object: null prototype],
      _eventsCount: 3,
      _maxListeners: undefined,
      socket: [TLSSocket],
      httpVersionMajor: 1,
      httpVersionMinor: 1,
      httpVersion: '1.1',
      complete: true,
      headers: [Object],
      rawHeaders: [Array],
      trailers: {},
      rawTrailers: [],
      aborted: false,
      upgrade: false,
      url: '',
      method: null,
      statusCode: 500,
      statusMessage: 'Server Error',
      client: [TLSSocket],
      _consuming: false,
      _dumped: false,
      req: [ClientRequest],
      setEncoding: [Function (anonymous)],
      on: [Function (anonymous)],
      text: '\n' +
        '  \n' +
        '  <!DOCTYPE html><html><head resURL="/static/ec88cfd3" data-rooturl="" data-resurl="/static/ec88cfd3">\n' +
        '    \n' +
        '\n' +
        `    <title>Jenkins [Jenkins]</title><link rel="stylesheet" href="/static/ec88cfd3/css/layout-common.css" type="text/css"><link rel="stylesheet" href="/static/ec88cfd3/css/style.css" type="text/css"><link rel="stylesheet" href="/static/ec88cfd3/css/color.css" type="text/css"><link rel="stylesheet" href="/static/ec88cfd3/css/responsive-grid.css" type="text/css"><link rel="shortcut icon" href="/static/ec88cfd3/favicon.ico" type="image/vnd.microsoft.icon"><link color="
...
```

This PR prevents the source 'host' header from being copied to the target HTTP connection.