### PR TITLE
Reset content-length header

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,15 @@ class Client {
 
     const req = superagent.post(target).send(data.body)
 
+    const data_len = JSON.stringify(data.body).length
+
     delete data.body
 
     Object.keys(data).forEach(key => {
       req.set(key, data[key])
     })
+
+    req.set('content-length', `${data_len}`)
 
     req.end((err, res) => {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class Client {
 
     const req = superagent.post(target).send(data.body)
 
-    const data_len = JSON.stringify(data.body).length
+    const dataLen = JSON.stringify(data.body).length
 
     delete data.body
 
@@ -34,7 +34,7 @@ class Client {
       req.set(key, data[key])
     })
 
-    req.set('content-length', `${data_len}`)
+    req.set('content-length', `${dataLen}`)
 
     req.end((err, res) => {
       if (err) {


### PR DESCRIPTION
Resets the `content-length` header after smee removes whitespace from JSON body. Addresses issues #136 and #116.