### PR TITLE
Add target host to new request

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,8 @@ class Client {
 
     delete data.query
 
+    data.host = target.hostname
+
     const req = superagent.post(url.format(target)).send(data.body)
 
     delete data.body

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,5 +12,25 @@ describe('client', () => {
       expect(channel).toEqual('https://smee.io/abc123')
       expect(req.isDone()).toBe(true)
     })
+  }),
+  describe('onmessage', () => {
+    test('forwards host header correctly', () => {
+      const scope = nock('https://example.com')
+          .matchHeader('host', 'example.com')
+          .post('/target-path')
+          .reply(201, '')
+
+      const logger = {info: (msg: any) => {}}
+
+      const client = new Client({
+        source: 'https://smee.io/example',
+        target: 'https://example.com/target-path',
+        logger: <Console>logger
+      });
+
+      client.onmessage({data:'{}'})
+
+      expect(scope.isDone()).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Originally intended to address #170 but is an alternative fix to the solution proposed in #162. It turns out that the data in the message contains the original host header and is passed on to the target as a header. I *think* that rewriting it is better than removing it (proposed in #170) as it makes it possible or smee client to work behind a reverse proxy (nginx, like Laravel Valet) or some Docker environments (using something like traefik as I am).

----

Relatively new to typescript, Node.js, and jest at this level, so unclear if there was a better way to handle the testing. The issue I ran into was the logging output in the success handler.

> Cannot log after tests are done. Did you forget to wait for something async in your test?

I couldn't find out a way to get around this issue without either 1) making logging optional, 2) including an additional optional callback so that we could call it when the response was completed 3) ???. So, I opted to fake it for now.

If there is a better way for me to do this let me know!