### PR TITLE
fixes commander 9.0.0 opts and http content-length violation

### DIFF
--- a/bin/smee.js
+++ b/bin/smee.js
@@ -13,16 +13,17 @@ program
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
   .parse(process.argv)
+const options = program.opts();
 
 let target
-if (program.target) {
-  target = program.target
+if (options.target) {
+  target = options.target
 } else {
-  target = `http://127.0.0.1:${program.port}${program.path}`
+  target = `http://127.0.0.1:${options.port}${options.path}`
 }
 
 async function setup () {
-  let source = program.url
+  let source = options.url
 
   if (!source) {
     source = await Client.createChannel()

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ class Client {
   logger: Pick<Console, Severity>;
   events!: EventSource;
 
-  constructor ({ source, target, logger = console }: Options) {
+  constructor({ source, target, logger = console }: Options) {
     this.source = source
     this.target = target
     this.logger = logger!
@@ -28,13 +28,13 @@ class Client {
     }
   }
 
-  static async createChannel () {
+  static async createChannel() {
     return superagent.head('https://smee.io/new').redirects(0).catch((err) => {
       return err.response.headers.location
     })
   }
 
-  onmessage (msg: any) {
+  onmessage(msg: any) {
     const data = JSON.parse(msg.data)
 
     const target = url.parse(this.target, true)
@@ -48,6 +48,9 @@ class Client {
     delete data.body
 
     Object.keys(data).forEach(key => {
+      if (key === 'content-length') {
+        return;
+      }
       req.set(key, data[key])
     })
 
@@ -60,15 +63,15 @@ class Client {
     })
   }
 
-  onopen () {
+  onopen() {
     this.logger.info('Connected', this.events.url)
   }
 
-  onerror (err: any) {
+  onerror(err: any) {
     this.logger.error(err)
   }
 
-  start () {
+  start() {
     const events = new EventSource(this.source);
 
     // Reconnect immediately


### PR DESCRIPTION
* Received payload via SSE includes content-length` HTTP header and we should not override it, since we use `superagent` as HTTP client, it should set its down `content-length` header and we should not override it. This fixes scenarios where the payload encoded by superagent does not match the content-length received by the smee service. Fixes https://github.com/probot/smee-client/issues/136 and https://github.com/probot/smee-client/issues/116
* Fixes entry point `smee.js`, commander 9.0.0 (https://github.com/probot/smee-client/pull/211) uses `program.opts()` to expose parsed commands
