### PR TITLE
chore: resolve codeql warning in unit test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,7 @@ describe("client", () => {
   describe("createChannel", () => {
     test("returns a new channel", async () => {
       const channel = await Client.createChannel();
-      expect(channel).toMatch(/https:\/\/smee\.io\/[0-9a-zA-Z]{10,}/);
+      expect(channel).toMatch(/^https:\/\/smee\.io\/[0-9a-zA-Z]{10,}$/);
     });
 
     test("throws if could not create a new channel", async () => {


### PR DESCRIPTION
This is a small fix for a codeql warning in the tests. We can merge this without a release, as we are not shipping tests with our npm packages.