### PR TITLE
fix: Incorrect JSON formatting in forwarded payload

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -66,6 +66,7 @@ class Client {
     });
 
     headers["content-length"] = Buffer.byteLength(body);
+    headers["content-type"] = "application/json";
 
     try {
       const response = await this.fetch(url.format(target), {


### PR DESCRIPTION
This PR aims to fix the issue with the forwarded payload not being in the correct JSON format.

#### Current (Incorrect) Format:
```json
"1716450473706": {
    "{"name":"Dasun Tharanga","email":"hello@dasun.dev"}":""
}
```

#### Corrected Format:
```json
"1716450473706": {
    "name": "Dasun Tharanga",
    "email": "hello@dasun.dev"
}