### PR TITLE
fix: add proxy support for `EventSource`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ events.close()
 #### Proxy
 
 By default, the Smee client does not make use of the standard proxy server environment variables. To add support for proxy servers you will need to provide an https client that supports them such as [`undici.EnvHttpProxyAgent()`](https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent).
+
 Afterwards, you will be able to use the standard proxy server environment variables.
 
 For example, this would use a `EnvHttpProxyAgent` to make requests through a proxy server:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,31 @@ const events = smee.start()
 // Stop forwarding events
 events.close()
 ```
+
+#### Proxy
+
+By default, the Smee client does not make use of the standard proxy server environment variables. To add support for proxy servers you will need to provide an https client that supports them such as [`undici.EnvHttpProxyAgent()`](https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent).
+Afterwards, you will be able to use the standard proxy server environment variables.
+
+For example, this would use a `EnvHttpProxyAgent` to make requests through a proxy server:
+
+```js
+const { EnvHttpProxyAgent, fetch: undiciFetch } = require("undici");
+const SmeeClient = require('smee-client');
+
+const myFetch = (url, options) => {
+  return undiciFetch(url, {
+    ...options,
+    dispatcher: new EnvHTTPProxyAgent()
+  })
+};
+
+const smee = new SmeeClient({
+  source: 'https://smee.io/abc123',
+  target: 'http://localhost:3000/events',
+  logger: console,
+  fetch: myFetch
+});
+
+const events = smee.start();
+```

--- a/index.ts
+++ b/index.ts
@@ -95,7 +95,9 @@ class Client {
   }
 
   start() {
-    const events = new EventSource(this.source);
+    const events = new EventSource(this.source, {
+      proxy: process.env.HTTP_PROXY || process.env.HTTPS_PROXY,
+    });
 
     // Reconnect immediately
     (events as any).reconnectInterval = 0; // This isn't a valid property of EventSource


### PR DESCRIPTION
This PR adds proxy support for the `EventSource` which was missing.
Fixes #194