### PR TITLE
fix: don't use undici EventSource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "commander": "^12.0.0",
+        "eventsource": "^3.0.5",
         "undici": "^6.19.8",
         "validator": "^13.11.0"
       },
@@ -1466,6 +1467,27 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.5.tgz",
+      "integrity": "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^12.0.0",
+    "eventsource": "^3.0.5",
     "undici": "^6.19.8",
     "validator": "^13.11.0"
   },


### PR DESCRIPTION
Unfortunately it isn't suitable as it completely swallows errors with no way of getting them.

No errors are thrown, and no details are included in the `error` event.