### PR TITLE
feat: allow passing of headers to delete from source

### DIFF
--- a/bin/smee.js
+++ b/bin/smee.js
@@ -21,6 +21,7 @@ program
   )
   .option("-p, --port <n>", "Local HTTP server port", process.env.PORT || 3000)
   .option("-P, --path <path>", "URL path to post proxied requests to`", "/")
+  .option("-h, --deleteHeaders <headers>", "List of headers to remove from request, comma separated", "")
   .parse(process.argv);
 
 const opts = program.opts();
@@ -29,12 +30,17 @@ const { target = `http://127.0.0.1:${opts.port}${opts.path}` } = opts;
 
 async function setup() {
   let source = opts.url;
+  let headersToDelete;
+
+  if(opts.deleteHeaders){
+    headersToDelete = opts.deleteHeaders.split(",");
+  }
 
   if (!source) {
     source = await Client.createChannel();
   }
 
-  const client = new Client({ source, target });
+  const client = new Client({ source, target, deleteHeaders: headersToDelete});
   client.start();
 }
 

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ interface Options {
   target: string;
   logger?: Pick<Console, Severity>;
   fetch?: any;
+  deleteHeaders?: Array<string>;
 }
 
 const proxyAgent = new EnvHttpProxyAgent();
@@ -24,19 +25,24 @@ class Client {
   #source: string;
   #target: string;
   #fetch: typeof undiciFetch;
+  #deleteHeaders: Array<string>;
+  
   #logger: Pick<Console, Severity>;
   #events!: EventSource;
+
 
   constructor({
     source,
     target,
     logger = console,
     fetch = undiciFetch,
+    deleteHeaders = []
   }: Options) {
     this.#source = source;
     this.#target = target;
     this.#logger = logger!;
     this.#fetch = fetch;
+    this.#deleteHeaders = deleteHeaders;
 
     if (!validator.isURL(this.#source)) {
       throw new Error("The provided URL is invalid.");
@@ -78,6 +84,7 @@ class Client {
     // See https://github.com/probot/smee-client/issues/295
     // See https://github.com/probot/smee-client/issues/187
     delete headers["host"];
+    this.#deleteHeaders.forEach((header) => delete headers[header]);
     headers["content-length"] = Buffer.byteLength(body);
     headers["content-type"] = "application/json";
 


### PR DESCRIPTION
Hello,

I've been using the client for a few weeks and have hit issues similar to;
https://github.com/probot/smee-client/issues/295
https://github.com/probot/smee-client/issues/187

As a result I ended up making the following alterations to the code to allow for the deletion of headers from the source request and for that list to passed as an arguement to the client. I figured this change may have some utility to others as it does for my team. Please let me know if I have missed anything on this PR