### PR TITLE
fix: don't send the raw Buffer data in the headers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,8 +65,11 @@ class Client {
 
     delete data.query;
 
-    const body = JSON.stringify(data.body);
+    const body = data.body;
     delete data.body;
+
+    const rawData = data.rawdata;
+    delete data.rawdata;
 
     const headers: { [key: string]: any } = {};
 
@@ -85,7 +88,8 @@ class Client {
       const response = await this.#fetch(url.format(target), {
         method: "POST",
         mode: data["sec-fetch-mode"],
-        body,
+        // Take advantage of the `rawData` field to send the original request body in order to be able to verify the signature
+        body: JSON.stringify({ body, rawData }),
         headers,
         dispatcher: proxyAgent,
       });


### PR DESCRIPTION
Take advantage of the `rawData` field in octokit in order to keep raw payload available to users and not get HTTP 431

Fixes #320