### PR TITLE
Refactor target URL assignment to remove trailing slash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -125,7 +125,7 @@ class SmeeClient {
     validateURL(source);
 
     this.#source = trimTrailingSlash(new URL(source).toString());
-    this.#target = trimTrailingSlash(new URL(target).toString());
+    this.#target = new URL(target).toString();
     this.#logger = logger!;
     this.#fetch = fetch;
     this.#queryForwarding = queryForwarding;


### PR DESCRIPTION
Im only partially reverting a recent change. Removing the trailing slash is fine for the source, but on the target it may cause issues. For example, Django is sensitive to trailing slashes in URLs, and developers should have the flexibility to include or omit them as needed.